### PR TITLE
Revert "Disable buildjet for now"

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -14,8 +14,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        runner: [ ubuntu-22.04 ]
-        #  paketo-community does not have access to buildjet      , buildjet-4vcpu-ubuntu-2204-arm ]
+        runner: [ ubuntu-22.04, buildjet-4vcpu-ubuntu-2204-arm ]
     outputs:
       release_notes: ${{ steps.notes.outputs.body }}
     steps:

--- a/.github/workflows/test-builder.yml
+++ b/.github/workflows/test-builder.yml
@@ -10,8 +10,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        runner: [ ubuntu-22.04 ]
-        #  paketo-community does not have access to buildjet      , buildjet-4vcpu-ubuntu-2204-arm ]
+        runner: [ ubuntu-22.04, buildjet-4vcpu-ubuntu-2204-arm ]
     steps:
     - name: Setup Go
       uses: actions/setup-go@v3

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -11,8 +11,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        runner: [ ubuntu-22.04 ]
-        #  paketo-community does not have access to buildjet      , buildjet-4vcpu-ubuntu-2204-arm ]
+        runner: [ ubuntu-22.04, buildjet-4vcpu-ubuntu-2204-arm ]
 
     steps:
     - name: Setup Go


### PR DESCRIPTION
This reverts commit 73c0adefd8115f515e3db7c3748729473834624f.

they've been enabled in paketo-community
